### PR TITLE
In case no timebounds input given - timebounds should be none

### DIFF
--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -330,7 +330,10 @@ Libify.buildTransaction = function(attributes, operations, networkObj) {
       maxTime: '0'
     });
 
-    var transaction = new KinSdk.TransactionBuilder(account, opts)
+    var transaction = new KinSdk.TransactionBuilder(account, opts);
+    if (attributes.minTime === '' && attributes.maxTime === ''){
+      transaction.timebounds = undefined;
+    }
     transaction.timeoutSet = true;  // TODO: ugly! setTimeout sets it, otherwise build() fails.
 
     if (attributes.memoType !== 'MEMO_NONE' && attributes.memoType !== '') {


### PR DESCRIPTION
previously both minTime and maxTime were always 0, and you weren't able to simulate a case of no timeout (like when setting infinite timeout (`TimeoutInfinite`) set via  js`TransactionBuilder.setTimeout()` )