### PR TITLE
Support whitelist singers in xdrviewer

### DIFF
--- a/src/actions/network.js
+++ b/src/actions/network.js
@@ -33,6 +33,7 @@ export function chooseNetwork(name) {
       name,
       horizonURL: NETWORK.available[name].horizonURL,
       networkPassphrase: NETWORK.available[name].networkPassphrase,
+      whitelistManager: NETWORK.available[name].whitelistManager
     }
   }
 }

--- a/src/components/NetworkPicker.js
+++ b/src/components/NetworkPicker.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import {chooseNetwork, setModalVisibility, updateModal, setCustomParams} from "../actions/network";
 import NETWORK from '../constants/network';
 import TextPicker from './FormComponents/TextPicker.js';
+import {Keypair} from '@kinecosystem/kin-base';
 
 class NetworkPicker extends React.Component {
   render() {
@@ -35,6 +36,12 @@ class NetworkPicker extends React.Component {
                 value={modal.values.networkPassphrase}
                 onUpdate={(value) => dispatch(updateModal('networkPassphrase', value))}
                 />
+              <p>Whitelist Manager:</p>
+              <TextPicker
+                value={modal.values.whitelistManager}
+                validator={isValidPublicAddress}
+                onUpdate={(value) => dispatch(updateModal('whitelistManager', value))}
+                />
               <button className="s-button"
                 disabled={false}
                 onClick={() => dispatch(setCustomParams(modal.values))}
@@ -63,6 +70,15 @@ const isValidHorizonURL = (u) => {
     return true;
   } catch (e) {
     return "Value is not a valid URL";
+  }
+}
+
+const isValidPublicAddress = (u) => {
+  try {
+    Keypair.fromPublicKey(u);
+    return true;
+  } catch (e) {
+    return "Value is not a valid public address"
   }
 }
 

--- a/src/components/XdrViewer.js
+++ b/src/components/XdrViewer.js
@@ -9,7 +9,7 @@ import {updateXdrInput, updateXdrType, fetchLatestTx, fetchSigners} from '../act
 import {xdr} from '@kinecosystem/kin-sdk';
 
 function XdrViewer(props) {
-  let {dispatch, state, baseURL, networkPassphrase} = props;
+  let {dispatch, state, baseURL, networkPassphrase, whitelistManager} = props;
 
   let validation = validateBase64(state.input);
   let messageClass = validation.result === 'error' ? 'xdrInput__message__alert' : 'xdrInput__message__success';
@@ -32,7 +32,7 @@ function XdrViewer(props) {
 
   // Fetch signers on initial load
   if (state.type === "TransactionEnvelope" && state.fetchedSigners === null) {
-    dispatch(fetchSigners(state.input, baseURL, networkPassphrase))
+    dispatch(fetchSigners(state.input, baseURL, networkPassphrase, whitelistManager))
   }
 
   return <div>
@@ -43,7 +43,7 @@ function XdrViewer(props) {
           <p>The XDR Viewer is a tool that displays contents of a Kin XDR blob in a human readable format.</p>
         </div>
         <p className="XdrViewer__label">
-        Input a base-64 encoded XDR blob, or <a onClick={() => dispatch(fetchLatestTx(baseURL, networkPassphrase))}>fetch the latest transaction to try it out</a>:
+        Input a base-64 encoded XDR blob, or <a onClick={() => dispatch(fetchLatestTx(baseURL, networkPassphrase, whitelistManager))}>fetch the latest transaction to try it out</a>:
         </p>
         <div className="xdrInput__input">
           <textarea
@@ -52,7 +52,7 @@ function XdrViewer(props) {
             onChange={(event) => {
               dispatch(updateXdrInput(event.target.value));
               if (state.type === "TransactionEnvelope") {
-                dispatch(fetchSigners(event.target.value, baseURL, networkPassphrase))
+                dispatch(fetchSigners(event.target.value, baseURL, networkPassphrase, whitelistManager))
               }
             }}
             placeholder="Example: AAAAAGXNhB2hIkbP//jgzn4os/AAAAZAB+BaLPAAA5Q/xL..."></textarea>
@@ -84,7 +84,8 @@ function chooseState(state) {
   return {
     state: state.xdrViewer,
     baseURL: state.network.current.horizonURL,
-    networkPassphrase: state.network.current.networkPassphrase
+    networkPassphrase: state.network.current.networkPassphrase,
+    whitelistManager: state.network.current.whitelistManager
   }
 }
 

--- a/src/constants/network.js
+++ b/src/constants/network.js
@@ -2,11 +2,13 @@ const NETWORK = {
   available: {
     public: {
       horizonURL: 'https://horizon-block-explorer.kininfrastructure.com',
-      networkPassphrase: 'Kin Mainnet ; December 2018'
+      networkPassphrase: 'Kin Mainnet ; December 2018',
+      whitelistManager: 'GCPGMBNS42RQODVI7JCIRZDOO2PKS3BDNHEL45YMB7PLGJP65FS7U4UV'
     },
     test: {
       horizonURL: 'https://horizon-testnet.kininfrastructure.com',
-      networkPassphrase: 'Kin Testnet ; December 2018'
+      networkPassphrase: 'Kin Testnet ; December 2018',
+      whitelistManager: 'GD7DQHW4C5BGKGBKD3HXTXX4QPUIRZXREIR5UIPSVI7EI6LEXHW7SZBT'
     }
   },
   defaultName: 'public',

--- a/src/reducers/network.js
+++ b/src/reducers/network.js
@@ -6,7 +6,8 @@ import {LOAD_STATE} from '../actions/routing';
 let defaultNetwork = {
   name: NETWORK.defaultName,
   horizonURL: NETWORK.available[NETWORK.defaultName].horizonURL,
-  networkPassphrase: NETWORK.available[NETWORK.defaultName].networkPassphrase
+  networkPassphrase: NETWORK.available[NETWORK.defaultName].networkPassphrase,
+  whitelistManager: NETWORK.available[NETWORK.defaultName].whitelistManager
 };
 
 let current = (state=defaultNetwork, action) => {
@@ -16,7 +17,8 @@ let current = (state=defaultNetwork, action) => {
         return {
           name: action.queryObj.network,
           horizonURL: action.queryObj.horizonURL,
-          networkPassphrase: action.queryObj.networkPassphrase
+          networkPassphrase: action.queryObj.networkPassphrase,
+          whitelistManager: action.queryObj.whitelistManager
         }
       }
 


### PR DESCRIPTION
Added support for whitelisting in the xdr viewer:

1. When choosing a network, you can now also add a "Whitelist Manager", the account where all the whitelisters are stored

2. When viewing a transaction in the xdr viewer, signatures from whitelisters are also considered valid, prior to this change their signatures were marked as invalid, which confused some of the devs